### PR TITLE
Fix simulation duration off-by-one

### DIFF
--- a/src/lib/simulationEngine.test.ts
+++ b/src/lib/simulationEngine.test.ts
@@ -76,13 +76,13 @@ describe('simulationEngine core functions', () => {
         mockEntityGSD('E2', 6, [12]),
       ];
       const mintEvents: MintEvent[] = [];
-      expect(getSimulationDurationInTimeSteps(entities, mintEvents, 'Month')).toBe(36);
+      expect(getSimulationDurationInTimeSteps(entities, mintEvents, 'Month')).toBe(37);
     });
 
     it('should calculate duration based on the latest mint event if it extends beyond vesting', () => {
       const entities = [mockEntityGSD('E1', 12, [24])];
       const mintEvents = [mockMintEventGSD(48)];
-      expect(getSimulationDurationInTimeSteps(entities, mintEvents, 'Month')).toBe(48);
+      expect(getSimulationDurationInTimeSteps(entities, mintEvents, 'Month')).toBe(49);
     });
 
     it('should ensure a minimum duration of 1 time step', () => {
@@ -94,10 +94,10 @@ describe('simulationEngine core functions', () => {
     it('should correctly use timeStep for duration calculation', () => {
       const entities = [mockEntityGSD('E1', 12, [24])]; 
       const mintEvents: MintEvent[] = [];
-      const expectedWeeks = convertMonthsToTimeSteps(36, 'Week');
+      const expectedWeeks = convertMonthsToTimeSteps(36, 'Week') + 1;
       expect(getSimulationDurationInTimeSteps(entities, mintEvents, 'Week')).toBe(expectedWeeks);
       
-      const expectedQuarters = convertMonthsToTimeSteps(36, 'Quarter');
+      const expectedQuarters = convertMonthsToTimeSteps(36, 'Quarter') + 1;
       expect(getSimulationDurationInTimeSteps(entities, mintEvents, 'Quarter')).toBe(expectedQuarters);
     });
 

--- a/src/lib/simulationEngine.ts
+++ b/src/lib/simulationEngine.ts
@@ -112,7 +112,8 @@ export function getSimulationDurationInTimeSteps(entities: Entity[], mintEvents:
     (ev) => (maxMonths = Math.max(maxMonths, ev.month))
   );
   const duration = convertMonthsToTimeSteps(maxMonths, timeStep);
-  return Math.max(1, duration); 
+  // Add one extra step so events exactly at the final month are processed
+  return Math.max(1, duration + 1);
 }
 
 /**


### PR DESCRIPTION
## Summary
- fix getSimulationDurationInTimeSteps to include final month step
- update tests for new duration logic

## Testing
- `npm test` *(fails: vitest not found)*